### PR TITLE
feat(admin): 회원가입 및 인증 API 연동

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -20,6 +20,7 @@
     "@types/node": "^16.18.126",
     "@types/styled-components": "^5.1.26",
     "axios": "^1.8.4",
+    "jotai": "^2.12.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.5.0",

--- a/apps/admin/src/components/Button.tsx
+++ b/apps/admin/src/components/Button.tsx
@@ -1,29 +1,49 @@
 import { ReactNode } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Text } from '@teka/ui';
 import { color } from '@teka/design-system';
+
+type ButtonVariant = 'primary' | 'disabled';
 
 interface ButtonProps {
   children: ReactNode;
   onClick: () => void;
+  variant?: ButtonVariant;
 }
 
-const Button = ({ children, onClick }: ButtonProps) => {
+const Button = ({ children, onClick, variant = 'primary' }: ButtonProps) => {
   return (
-    <StyledButton onClick={onClick}>
-      <Text fontType='semibold16' color={color.white}>{children}</Text>
+    <StyledButton
+      onClick={variant === 'disabled' ? undefined : onClick}
+      variant={variant}
+    >
+      <Text fontType="semibold16" color={color.white}>
+        {children}
+      </Text>
     </StyledButton>
   );
 };
 
 export default Button;
 
-const StyledButton = styled.div`
+const StyledButton = styled.div<{ variant: ButtonVariant }>`
   width: 100%;
   max-width: 400px;
   padding: 15px 0px;
-  background-color: ${color.blue800};
   border-radius: 12px;
   display: block;
   text-align: center;
+  cursor: pointer;
+  user-select: none;
+
+  ${({ variant }) =>
+    variant === 'primary'
+      ? css`
+          background-color: ${color.blue800};
+        `
+      : css`
+          background-color: ${color.gray100};
+          pointer-events: none;
+          cursor: not-allowed;
+        `}
 `;

--- a/apps/admin/src/constants/constant.ts
+++ b/apps/admin/src/constants/constant.ts
@@ -9,3 +9,7 @@ export const TOKEN = {
   ACCESS: 'access-token',
   REFRESH: 'refresh-token',
 } as const;
+
+export const KEY = {
+  VALIDATE: 'useValidateKey',
+}

--- a/apps/admin/src/hooks/useApiError.ts
+++ b/apps/admin/src/hooks/useApiError.ts
@@ -1,0 +1,38 @@
+import { isAxiosError } from 'axios';
+import type { AxiosError } from 'axios';
+
+interface AxiosErrorResponse {
+  code: string;
+  message: string;
+}
+
+type ErrorStatus = 403 | 429 | 500;
+
+const ERROR: Record<ErrorStatus, string> = {
+  403: '다시 로그인 후 시도해주세요.',
+  429: '너무 많이 요청하였습니다. 조금 뒤 다시 이용해주세요.',
+  500: '서버에 알 수 없는 오류가 발생했습니다.',
+};
+
+const useApiError = () => {
+  const handleError = (error: AxiosError<AxiosErrorResponse>) => {
+    let errorMessage = '';
+    if (isAxiosError(error)) {
+      if (error.response) {
+        const status = error.response.status as ErrorStatus;
+        const maessage = error.response.data.message;
+        errorMessage = maessage || ERROR[status];
+        if (status === 500) {
+          throw new Error('500');
+        }
+      }
+    } else {
+      errorMessage = '알 수 없는 오류가 발생했습니다.';
+    }
+    errorMessage && alert(errorMessage);
+  };
+
+  return { handleError };
+};
+
+export default useApiError;

--- a/apps/admin/src/pages/signup/page.tsx
+++ b/apps/admin/src/pages/signup/page.tsx
@@ -1,25 +1,67 @@
 import Button from '@/components/Button';
-import { ButtonInput, Column, PreviewInput } from '@teka/ui';
+import { ButtonInput, Column, PreviewInput, Text } from '@teka/ui';
 import { flex } from '@teka/utils';
 import styled from 'styled-components';
+import { useInput, useSingupAction, useVerificationAction } from './singup.hooks';
+import { color } from '@teka/design-system';
 
 const SignupPage = () => {
+  const { signup, handleSignupChange } = useInput();
+  const { handleSignup } = useSingupAction(signup);
+  const { handleValidate, isSuccess, isError } = useVerificationAction(signup);
+
+  const isFormValid = signup.username && signup.password && signup.password_confirm;
+  const isPasswordMatching = signup.password === signup.password_confirm;
+
   return (
     <StyledSignupPage>
       <SignupPageBox>
         <img src="/logo.svg" alt="logo" />
         <Column gap={122} width="100%" alignItems="center">
           <Column gap={32} width="100%" alignItems="center">
-            <ButtonInput
-              buttonText="중복 확인"
-              onClick={() => {}}
-              label="아이디"
-              placeholder="아이디를 입력해주세요"
+            <Column gap={4} width="100%" alignItems="flex-start">
+              <ButtonInput
+                buttonText="중복 확인"
+                name="username"
+                onClick={handleValidate}
+                label="아이디"
+                width="100%"
+                placeholder="아이디를 입력해주세요"
+                onChange={handleSignupChange}
+                value={signup.username}
+                enabled={!!signup.username}
+              />
+              {isError && (
+                <Text fontType="regular12" color={color.red900}>
+                  중복된 아이디입니다
+                </Text>
+              )}
+              {isSuccess && (
+                <Text fontType="regular12" color={color.blue800}>
+                  사용 가능한 아이디입니다
+                </Text>
+              )}
+            </Column>
+            <PreviewInput
+              label="비밀번호"
+              placeholder="비밀번호를 입력해주세요"
+              width="100%"
+              name="password"
+              onChange={handleSignupChange}
             />
-            <PreviewInput label="비밀번호" placeholder="비밀번호를 입력해주세요" />
-            <PreviewInput label="비밀번호" placeholder="비밀번호를 입력해주세요" />
+            <PreviewInput
+              width="100%"
+              label="비밀번호 재입력"
+              placeholder="비밀번호를 다시 입력해주세요"
+              name="password_confirm"
+              onChange={handleSignupChange}
+              isError={signup.password !== signup.password_confirm}
+              errorMessage="비밀번호가 일치하지 않습니다."
+            />
           </Column>
-          <Button onClick={() => {}}>가입 완료</Button>
+          <Button onClick={handleSignup} variant={isFormValid && isPasswordMatching && isSuccess ? 'primary' : 'disabled'}>
+            가입 완료
+          </Button>
         </Column>
       </SignupPageBox>
     </StyledSignupPage>

--- a/apps/admin/src/pages/signup/singup.hooks.ts
+++ b/apps/admin/src/pages/signup/singup.hooks.ts
@@ -1,0 +1,45 @@
+import { useSignupMutation } from '@/services/admin/mutations';
+import { useValidateQuery } from '@/services/admin/queries';
+import { signupAtom } from '@/stores/signup';
+import { Signup } from '@/types/admin/client';
+import { useAtom } from 'jotai';
+import { ChangeEventHandler } from 'react';
+
+export const useInput = () => {
+  const [signup, setSignup] = useAtom(signupAtom);
+
+  const handleSignupChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { name, value } = e.target;
+
+    setSignup({ [name]: value });
+  };
+
+  return { signup, handleSignupChange };
+};
+
+export const useSingupAction = (signupData: Signup) => {
+  const { signupMutate } = useSignupMutation(signupData);
+
+  const handleSignup = () => {
+    signupMutate();
+  };
+
+  return { handleSignup };
+};
+
+export const useVerificationAction = (signupData: Signup) => {
+  const { refetch, isSuccess, data, isError } = useValidateQuery({
+    username: signupData.username,
+  });
+
+  const handleValidate = async () => {
+    await refetch();
+    if (isSuccess && data?.status === 200) {
+      alert('사용 가능한 아이디입니다.');
+    } else if (isError || data?.status === 400) {
+      alert('중복된 아이디입니다.');
+    }
+  };
+
+  return { handleValidate, isSuccess, isError };
+};

--- a/apps/admin/src/services/admin/api.ts
+++ b/apps/admin/src/services/admin/api.ts
@@ -1,0 +1,16 @@
+import { teka } from '@/apis/instance/instance';
+import { GetValidateReq, PostSignupReq } from '@/types/admin/remote';
+
+export const postSignup = async ({ username, password }: PostSignupReq) => {
+  const { data } = await teka.post('/admins', { username, password });
+
+  return data;
+};
+
+export const getValidate = async (username: GetValidateReq) => {
+  const { data } = await teka.get('/admins/validate', {
+    params: username,
+  });
+
+  return data;
+};

--- a/apps/admin/src/services/admin/mutations.ts
+++ b/apps/admin/src/services/admin/mutations.ts
@@ -1,0 +1,22 @@
+import { PostSignupReq } from '@/types/admin/remote';
+import { useMutation } from '@tanstack/react-query';
+import { postSignup } from './api';
+import useApiError from '@/hooks/useApiError';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants/constant';
+
+export const useSignupMutation = ({ username, password }: PostSignupReq) => {
+  const { handleError } = useApiError();
+  const navigate = useNavigate();
+
+  const { mutate: signupMutate, ...restMutation } = useMutation({
+    mutationFn: () => postSignup({ username, password }),
+    onSuccess: () => {
+      alert('회원가입 성공');
+      navigate(ROUTES.LOGIN);
+    },
+    onError: handleError,
+  });
+
+  return { signupMutate, ...restMutation };
+};

--- a/apps/admin/src/services/admin/queries.ts
+++ b/apps/admin/src/services/admin/queries.ts
@@ -3,10 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { getValidate } from './api';
 import { GetValidateReq } from '@/types/admin/remote';
 
-export const useValidateQuery = (username: GetValidateReq) => {
+export const useValidateQuery = ({ username }: GetValidateReq) => {
   const { data, ...restQuery } = useQuery({
-    queryKey: [KEY.VALIDATE],
-    queryFn: () => getValidate(username),
+    queryKey: [KEY.VALIDATE, username],
+    queryFn: () => getValidate({ username }),
+    enabled: false,
   });
 
   return { data, ...restQuery };

--- a/apps/admin/src/services/admin/queries.ts
+++ b/apps/admin/src/services/admin/queries.ts
@@ -1,0 +1,13 @@
+import { KEY } from '@/constants/constant';
+import { useQuery } from '@tanstack/react-query';
+import { getValidate } from './api';
+import { GetValidateReq } from '@/types/admin/remote';
+
+export const useValidateQuery = (username: GetValidateReq) => {
+  const { data, ...restQuery } = useQuery({
+    queryKey: [KEY.VALIDATE],
+    queryFn: () => getValidate(username),
+  });
+
+  return { data, ...restQuery };
+};

--- a/apps/admin/src/stores/signup.ts
+++ b/apps/admin/src/stores/signup.ts
@@ -1,0 +1,19 @@
+import { Signup } from '@/types/admin/client';
+import { atom } from 'jotai';
+
+const baseSignupAtom = atom<Signup>({
+  username: '',
+  password: '',
+  password_confirm: '',
+});
+
+export const signupAtom = atom(
+  (get) => get(baseSignupAtom),
+  (get, set, newSignup: Partial<Signup>) => {
+    const prev = get(baseSignupAtom);
+    set(baseSignupAtom, {
+      ...prev,
+      ...newSignup,
+    });
+  }
+);

--- a/apps/admin/src/types/admin/client.ts
+++ b/apps/admin/src/types/admin/client.ts
@@ -1,0 +1,5 @@
+export interface Signup {
+  username: string;
+  password: string;
+  password_confirm: string;
+}

--- a/apps/admin/src/types/admin/remote.ts
+++ b/apps/admin/src/types/admin/remote.ts
@@ -3,4 +3,6 @@ export interface PostSignupReq {
   password: string;
 }
 
-export type GetValidateReq = Omit<PostSignupReq, 'password'>;
+export interface GetValidateReq {
+  username: string;
+}

--- a/apps/admin/src/types/admin/remote.ts
+++ b/apps/admin/src/types/admin/remote.ts
@@ -1,0 +1,6 @@
+export interface PostSignupReq {
+  username: string;
+  password: string;
+}
+
+export type GetValidateReq = Omit<PostSignupReq, 'password'>;

--- a/packages/ui/src/Input/ButtonInput.tsx
+++ b/packages/ui/src/Input/ButtonInput.tsx
@@ -59,11 +59,11 @@ const StyledButtonInput = styled.div`
   gap: 7px;
 `;
 
-const Button = styled.button<{ disabled: boolean }>`
+const Button = styled.button`
   ${flex({ alignItems: 'center', justifyContent: 'center' })}
   ${font.medi14};
   color: ${color.white2};
-  background-color: ${({ disabled }) => (disabled ? color.gray400 : color.blue800)};
+  background-color: ${color.blue800};
   border-radius: 12px;
   height: 48px;
   padding: 0 16px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       axios:
         specifier: ^1.8.4
         version: 1.8.4
+      jotai:
+        specifier: ^2.12.3
+        version: 2.12.3(@types/react@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -8517,6 +8520,22 @@ packages:
   /jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+    dev: false
+
+  /jotai@2.12.3(@types/react@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-DpoddSkmPGXMFtdfnoIHfueFeGP643nqYUWC6REjUcME+PG2UkAtYnLbffRDw3OURI9ZUTcRWkRGLsOvxuWMCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.2.0
+      react: 18.2.0
     dev: false
 
   /js-tokens@4.0.0:


### PR DESCRIPTION
## 📄 Summary

> 회원가입 및 인증 API를 연동하고 페이지에 적용했습니다.

<br>

## 🔨 Tasks

- Jotai 설치
- 회원가입 API 연동
- 아이디 중복 확인 API 연동
- 페이지에 적용
- 로직 분리
- Button Disabled 조건 추가

<br>

## 🙋🏻 More
